### PR TITLE
Override method findOne to findOne with integer parameter, because all

### DIFF
--- a/IGRP/src/main/java/nosi/webapps/igrp/dao/IGRPBaseActiveRecord.java
+++ b/IGRP/src/main/java/nosi/webapps/igrp/dao/IGRPBaseActiveRecord.java
@@ -2,13 +2,24 @@ package nosi.webapps.igrp.dao;
 
 import nosi.base.ActiveRecord.BaseActiveRecord;
 import nosi.core.config.ConfigApp;
+import nosi.core.webapp.Core;
 
 public class IGRPBaseActiveRecord<T> extends BaseActiveRecord<T> {
 	
 	@Override
-    public String getConnectionName() {
-    	// TODO Auto-generated method stub
-    	//return Globals.CONNECTION_NAME;
+	public void setConnectionName(String connectionName) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public T findOne(Object value) {
+		if(value!=null)
+			return super.findOne(Core.toInt(value.toString()));
+		throw new IllegalArgumentException();
+	}
+	
+	@Override
+	public String getConnectionName() {
 		return new ConfigApp().getBaseConnection();
     }
 }


### PR DESCRIPTION
the IGRP entities declares ID as Integer