### PR TITLE
BaseActiveRecord optimization

### DIFF
--- a/IGRP/src/main/java/nosi/base/ActiveRecord/BaseActiveRecord.java
+++ b/IGRP/src/main/java/nosi/base/ActiveRecord/BaseActiveRecord.java
@@ -18,6 +18,8 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.annotations.QueryHints;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.gson.annotations.Expose;
@@ -849,6 +851,8 @@ public abstract class BaseActiveRecord<T> implements ActiveRecordIterface<T>, Se
 					query.setFirstResult(offset);
 				if(this.limit > -1)
 					query.setMaxResults(limit);
+				if(this.isReadOnly)
+					query.setHint("org.hibernate.readOnly", true);
 				this.setParameters(query);
 				list = query.getResultList();
 				transaction.commit();


### PR DESCRIPTION
…fetching entities in read-only mode is much more efficient than fetching read-write entities...
http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#hql-read-only-entities
